### PR TITLE
GC_FR-6 gemcook/formのDropdownで複数選択に選択数制限を実装する。

### DIFF
--- a/src/Dropdown/enhance.js
+++ b/src/Dropdown/enhance.js
@@ -7,19 +7,15 @@ const enhance: HOC<Props, *> = compose(
   withHandlers({
     handleOnChange: props => (event: SyntheticEvent<*>, data: Object) => {
       const {input, limit} = props;
-      const dropDownValues = [];
-
+      let count = 10;
       if (limit) {
-        for (let i = 0; i <= limit; i++) {
-          dropDownValues.push(data.value[i]);
-        }
-      } else {
-        const initialLimit = 10;
-        for (let i = 0; i <= initialLimit; i++) {
-          dropDownValues.push(data.value[i]);
-        }
+        count = limit;
       }
-      input.onChange(dropDownValues);
+      if (data.value.length <= count) {
+        return input.onChange(data.value);
+      } else {
+        return data.value;
+      }
     },
   }),
 );

--- a/src/Dropdown/enhance.js
+++ b/src/Dropdown/enhance.js
@@ -6,8 +6,20 @@ const enhance: HOC<Props, *> = compose(
   setDisplayName('GcDropdown'),
   withHandlers({
     handleOnChange: props => (event: SyntheticEvent<*>, data: Object) => {
-      const {input} = props;
-      input.onChange(data.value);
+      const {input, limit} = props;
+      const dropDownValues = [];
+
+      if (limit) {
+        for (let i = 0; i <= limit; i++) {
+          dropDownValues.push(data.value[i]);
+        }
+      } else {
+        const initialLimit = 10;
+        for (let i = 0; i <= initialLimit; i++) {
+          dropDownValues.push(data.value[i]);
+        }
+      }
+      input.onChange(dropDownValues);
     },
   }),
 );

--- a/src/stories/DropdownForm/index.jsx
+++ b/src/stories/DropdownForm/index.jsx
@@ -4,13 +4,31 @@ import {Field} from 'redux-form/immutable';
 import enhance from './enhancer';
 
 function DropdownForm(props: Object) {
-  const {fluid, dark, multiple, name, component, placeholder, options} = props;
+  const {
+    fluid,
+    dark,
+    multiple,
+    name,
+    component,
+    placeholder,
+    options,
+    limit,
+  } = props;
 
   return (
     <div>
       <form>
         <Field
-          {...{fluid, dark, multiple, name, component, placeholder, options}}
+          {...{
+            fluid,
+            dark,
+            multiple,
+            name,
+            component,
+            placeholder,
+            options,
+            limit,
+          }}
         />
       </form>
     </div>

--- a/src/stories/index.js
+++ b/src/stories/index.js
@@ -42,6 +42,7 @@ storiesOf('Dropdown', module)
         }}
       >
         <DropdownForm
+          limit={5}
           fluid
           dark
           multiple


### PR DESCRIPTION
### 課題URL

* https://gemcook.backlog.jp/view/GC_FR-6

### 動作確認ブランチ

| **frontend** | **backend** |
| :--- | :--- |
| *current branch* | develop |

### 動作確認方法

* `limit`propsを数値で定義してドロップダウンを選択する
* `limit`propsを定義せずにドロップダウンを選択する

### アサイニーが確認した項目

* `limit`propsを定義した場合、定義した数だけドロップダウンを選択できること
* `limit`propsを定義しなかった場合、10個までしかドロップダウンの選択ができないこと

### 技術的変更点

* 既に追加された値の合計数が選択制限数より小さければ、ドロップダウンの値を追加できるようにしました。
### レビュアーに対する注意点

* 動作確認のため`limit`propsを5にしています。

### 課題とは直接関係がないが修正した項目

* なし

### 今回保留した項目

* なし

### リリース・マージに対する注意点

* なし

### その他

* なし